### PR TITLE
Treat eval Exceptions as failed testresults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea/
+/*.iml
+ans-*

--- a/src/ctrain/core.clj
+++ b/src/ctrain/core.clj
@@ -12,22 +12,30 @@
   (loop [coll results]
     (if (empty? coll)
       (do
-      (spit "prob" (inc (read-string (slurp "prob"))))
-      (println "\nGOOD JOB! Here's the next one:")
+       (spit "prob" (inc (read-string (slurp "prob"))))
+       (println "\nGOOD JOB! Here's the next one:")
        (Thread/sleep 1000)
-      (-main)))
-   (if (= false (first coll))
+       (-main)))
+    (if (= false (first coll))
        (do
           (println "\nNope... try again or Ctrl+C to quit")
           (Thread/sleep 1000)
-       (-main)))
-(recur (rest coll))))
+          (-main)))
+    (recur (rest coll))))
 
 (defn evaluator [answers]
   (loop [totest answers results []]
     (if (empty? totest)
       (final results)
-      (recur (rest totest) (conj results (eval (read-string (first totest))))))))
+      (recur
+        (rest totest)
+        (conj results
+          (try
+             (eval (read-string (first totest)))
+             (catch Exception e
+               (println (str "Error evaluating: " (class e) ":" (.getMessage e)))
+               (.printStackTrace e)
+               false)))))))
 
 (defn replacer [n]
   (let [ans (slurp (str "ans-" n))]
@@ -36,19 +44,19 @@
           (println "Nice try, but blank answers are not allowed.")
           (Thread/sleep 1000)
           (-main)))
-(loop [tests (:tests (problems (- n 1))) replaced []]
-  (if (empty? tests)
-      (evaluator replaced)
-      (recur (rest tests) (conj replaced (s/replace (first tests) "__" ans)))))))
+    (loop [tests (:tests (problems (- n 1))) replaced []]
+        (if (empty? tests)
+          (evaluator replaced)
+          (recur (rest tests) (conj replaced (s/replace (first tests) "__" ans)))))))
 
 
 (defn problem [n]
   (println (str "\n#" n ": " (:title (nth problems (- n 1)))))
-   (println (str "\n" (:description (nth problems (- n 1)))) "\n")
-   (run! println (:tests (nth problems (- n 1))))
-   (spit (str "ans-" n)(read-line)))
+  (println (str "\n" (:description (nth problems (- n 1)))) "\n")
+  (run! println (:tests (nth problems (- n 1))))
+  (spit (str "ans-" n)(read-line)))
 
 (defn -main []
   (let [n (read-string (slurp "prob"))]
     (problem n)
-  (replacer n)))
+    (replacer n)))


### PR DESCRIPTION
In response to https://porkostomus.gitlab.io/posts-output/2018-09-16-day-2/

Sorry for all the indent diffs - using parinfer@cursive which changed some of it on file load and then i thought I'd go with it and cleaned up indentation a bit more for readability.